### PR TITLE
Fix: bug in address format when streetname is missing

### DIFF
--- a/Resources/public/js/leaflet-embed.js
+++ b/Resources/public/js/leaflet-embed.js
@@ -161,7 +161,7 @@ CuriousMap.prototype.updateFormFields = function (position) {
         var country = data.address.country || '';
 
         // Populate input fields if configured
-        if ($this.fields.address) $this.fields.address.$field.val($.trim(street + ' ' + houseNumber) + (street.length ? ', ' : '') + city);
+        if ($this.fields.address) $this.fields.address.$field.val($this.parseAddress(city, street, houseNumber));
         if ($this.fields.street) $this.fields.street.$field.val(street);
         if ($this.fields.postal_code) $this.fields.postal_code.$field.val(postCode);
         if ($this.fields.city) $this.fields.city.$field.val(city);
@@ -613,4 +613,23 @@ CuriousMap.prototype.snapToLocation = function () {
       .find('.alert_no_secure_connection')
       .show();
   }
+};
+
+/**
+ * Format the address
+ * We want either the city,
+ * or street (houseNumber if available), city
+ */
+CuriousMap.prototype.parseAddress = function (city, street, houseNumber) {
+  if (street.length && city.length) {
+    city = ', ' + city;
+  }
+
+  if (street.length && houseNumber.length) {
+    houseNumber = ' ' + houseNumber;
+  } else if (!street.length && houseNumber.length) {
+    houseNumber = '';
+  }
+
+  return street + houseNumber + city;
 };


### PR DESCRIPTION
fix: Address was displayed incorrectly when the street name was not present

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Did you think of everything? --> 
- [ X] I have read the **CONTRIBUTING** document.
- [ X] My code follows the code style of this project.
- [ X] I have updated the documentation where applicable.
