### PR TITLE
Make geojson visibility depend on zoomlevel

### DIFF
--- a/Resources/public/js/leaflet-embed.js
+++ b/Resources/public/js/leaflet-embed.js
@@ -210,7 +210,7 @@ CuriousMap.prototype.updateGeoJsonLayers = function () {
       && currentZoomLevel <= geoJsonLayerObject.settings.maxZoom
     ) {
       // Show layer based on min and max zoom level settings per layer
-      geoJsonLayerObject.layer.setStyle({ visibility: 'visible' });
+      geoJsonLayerObject.layer.setStyle({ opacity: 1, fillOpacity: 0.8 });
 
       // Update the layer within the object with new GeoJson data, if any
       var url = generateUrl(geoJsonLayerObject.settings);


### PR DESCRIPTION
# Make geojson visibility depend on zoomlevel

* Added: Hide and show the geojson overlay based on specified zoomlevels.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Did you think of everything? --> 
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] I have added or updated tests where necessary.
- [ ] I have updated the documentation where applicable.
