### PR TITLE
Fix missing marker after SnapToLocation

### DIFF
--- a/Resources/public/js/leaflet-embed.js
+++ b/Resources/public/js/leaflet-embed.js
@@ -126,6 +126,12 @@ CuriousMap.prototype.initialiseTriggers = function () {
   this.$searchBtn.on('click', function () {
     $this.searchAddress($this.$searchField.val());
   });
+
+  // When SnapToLocation succesfull
+  this.$map.on('locationfound', function (e) {
+    $this.updateLocation(e.latlng);
+  });
+
 };
 
 /**


### PR DESCRIPTION
# Fix marker after 'SnapToLocation'
* Fixed: missing marker after 'SnapToLocation' was successfully found

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [X] I have added or updated tests where necessary.
- [X] I have updated the documentation where applicable.
